### PR TITLE
Corrected python-2.7-111-optional-ssl.patch

### DIFF
--- a/package/python/python-2.7-111-optional-ssl.patch
+++ b/package/python/python-2.7-111-optional-ssl.patch
@@ -17,7 +17,7 @@ Index: Python-2.7.2/configure.in
 +AC_ARG_ENABLE(ssl,
 +	AS_HELP_STRING([--disable-ssl], [disable SSL]),
 +	[ if test "$enableval" = "no"; then
-+    	     DISABLED_EXTENSIONS="${DISABLED_EXTENSIONS} ssl"
++    	     DISABLED_EXTENSIONS="${DISABLED_EXTENSIONS} _ssl"
 +  	  fi])
 +
  AC_ARG_ENABLE(dbm,


### PR DESCRIPTION
The ssl module is called _ssl. setup.py would build it regardless of --disable-ssl without this change.
